### PR TITLE
APD-365 - [BE] add on_demand_fields autodoc

### DIFF
--- a/drf_tweaks/autodoc.py
+++ b/drf_tweaks/autodoc.py
@@ -170,6 +170,32 @@ class OrderingAndFilteringAutodoc(AutodocBase):
         return text
 
 
+class OnDemandFieldsAutodoc(AutodocBase):
+    @classmethod
+    def _generate_yaml(cls, documented_cls, method_name):
+        return ""
+
+    @classmethod
+    def _generate_text(cls, documented_cls, method_name):
+        serializer = getattr(documented_cls, "serializer_class", None)
+        if not serializer:
+            return ""
+
+        try:
+            on_demand_fields = serializer.Meta.on_demand_fields
+        except AttributeError:
+            on_demand_fields = set()
+
+        if not on_demand_fields:
+            return ""
+
+        on_demand_fields = sorted(on_demand_fields)
+        text = "\n\n<b>Access to on demand fields</b>\n\n\tavailable fields: "
+        text += "{}\n\n".format(", ".join(on_demand_fields))
+        text += "\n".join(["{} -- optional".format(field) for field in on_demand_fields])
+        return text
+
+
 class BaseInfoAutodoc(AutodocBase):
     """ insert the base docstring to each method - this will be displayed on the swagger folded list """
     @classmethod
@@ -201,7 +227,7 @@ if hasattr(settings, "AUTODOC_DEFAULT_CLASSESS"):
     DEFAULT_CLASSESS = [import_from_string(x, "") for x in settings.AUTODOC_DEFAULT_CLASSESS]
 else:
     DEFAULT_CLASSESS = (BaseInfoAutodoc, PermissionsAutodoc, OrderingAndFilteringAutodoc, PaginationAutodoc,
-                        VersioningAutodoc)
+                        VersioningAutodoc, OnDemandFieldsAutodoc)
 
 
 def autodoc(base_doc="", classess=DEFAULT_CLASSESS, add_classess=None, skip_classess=None):

--- a/drf_tweaks/autodoc.py
+++ b/drf_tweaks/autodoc.py
@@ -192,7 +192,6 @@ class OnDemandFieldsAutodoc(AutodocBase):
         on_demand_fields = sorted(on_demand_fields)
         text = "\n\n<b>Access to on demand fields</b>\n\n\tavailable fields: "
         text += "{}\n\n".format(", ".join(on_demand_fields))
-        text += "\n".join(["{} -- optional".format(field) for field in on_demand_fields])
         return text
 
 

--- a/drf_tweaks/autodoc.py
+++ b/drf_tweaks/autodoc.py
@@ -129,10 +129,6 @@ class OrderingAndFilteringAutodoc(AutodocBase):
 
 class OnDemandFieldsAutodoc(AutodocBase):
     @classmethod
-    def _generate_yaml(cls, documented_cls, method_name):
-        return ""
-
-    @classmethod
     def _generate_text(cls, documented_cls, method_name):
         serializer = getattr(documented_cls, "serializer_class", None)
         if not serializer:

--- a/drf_tweaks/autodoc.py
+++ b/drf_tweaks/autodoc.py
@@ -137,7 +137,7 @@ class OnDemandFieldsAutodoc(AutodocBase):
         try:
             on_demand_fields = serializer.Meta.on_demand_fields
         except AttributeError:
-            on_demand_fields = set()
+            return ""
 
         if not on_demand_fields:
             return ""

--- a/tests/test_autodoc.py
+++ b/tests/test_autodoc.py
@@ -10,11 +10,12 @@ from rest_framework.permissions import AllowAny
 from rest_framework.test import APITestCase
 from rest_framework.versioning import AcceptHeaderVersioning
 
-from drf_tweaks.autodoc import autodoc, BaseInfoAutodoc, PaginationAutodoc, PermissionsAutodoc
+from drf_tweaks.autodoc import autodoc, BaseInfoAutodoc, OnDemandFieldsAutodoc, PaginationAutodoc, PermissionsAutodoc
 from drf_tweaks.autofilter import autofilter
 from drf_tweaks.pagination import NoCountsLimitOffsetPagination
+from drf_tweaks.serializers import ModelSerializer
 from drf_tweaks.versioning import ApiVersionMixin
-from tests.models import SampleModelForAutofilter
+from tests.models import SampleModel, SampleModelForAutofilter
 
 
 # sample serializers
@@ -26,6 +27,18 @@ class SampleModelForAutofilterSerializer(serializers.ModelSerializer):
     class Meta:
         model = SampleModelForAutofilter
         fields = ["id", "fk", "non_indexed_fk", "indexed_int", "non_indexed_int", "indexed_char", "non_indexed_char"]
+
+
+class SampleOnDemandFieldsSerializer(ModelSerializer):
+    on_demand_field = serializers.SerializerMethodField()
+
+    def get_on_demand_field(self, obj):
+        return "on_demand"
+
+    class Meta:
+        model = SampleModel
+        fields = ["a"]
+        on_demand_fields = ["b", "on_demand_field"]
 
 
 class NoDocAllowAny(AllowAny):
@@ -137,6 +150,13 @@ class SampleAutofilterApiV3(ListAPIView):
     filter_fields = ("id", "fk")
     ordering_fields = ("id", "fk")
     pagination_class = None
+
+
+@autodoc(classess=(OnDemandFieldsAutodoc,))
+class SampleOnDemandAutodocApi(ListAPIView):
+    queryset = SampleModel.objects.all()
+    permission_classes = (AllowAny,)
+    serializer_class = SampleOnDemandFieldsSerializer
 
 
 # expected docstrings
@@ -261,6 +281,14 @@ FILTER_SORTING_GET = """Test
 \tid: exact"""
 
 
+ON_DEMAND_GET = """<b>Access to on demand fields</b>
+
+\tavailable fields: b, on_demand_field
+
+b -- optional
+on_demand_field -- optional"""
+
+
 class AutodocTestCase(APITestCase):
     def test_base_info_only(self):
         self.assertEqual(SampleNotVersionedApi.get.__doc__, BASE_INFO_WITH_PERMISSIONS)
@@ -286,3 +314,6 @@ class AutodocTestCase(APITestCase):
 
     def test_autodoc_for_filter_and_order(self):
         self.assertEqual(SampleAutofilterApiV3.get.__doc__, FILTER_SORTING_GET)
+
+    def test_autodoc_for_on_demand_fields(self):
+        self.assertEqual(SampleOnDemandAutodocApi.get.__doc__, ON_DEMAND_GET)

--- a/tests/test_autodoc.py
+++ b/tests/test_autodoc.py
@@ -283,10 +283,7 @@ FILTER_SORTING_GET = """Test
 
 ON_DEMAND_GET = """<b>Access to on demand fields</b>
 
-\tavailable fields: b, on_demand_field
-
-b -- optional
-on_demand_field -- optional"""
+\tavailable fields: b, on_demand_field"""
 
 
 class AutodocTestCase(APITestCase):


### PR DESCRIPTION
Unfortunately the `field -- optional` does not work in the latest swagger.
